### PR TITLE
DriveDroid changes

### DIFF
--- a/drivers/usb/gadget/android.c
+++ b/drivers/usb/gadget/android.c
@@ -1615,9 +1615,9 @@ static int mass_storage_function_init(struct android_usb_function *f,
 			config->fsg.nluns = FSG_MAX_LUNS;
 		for (i = 0; i < config->fsg.nluns; i++) {
 			if (dev->pdata->cdrom_lun & (1 << i)) {
-				config->fsg.luns[i].cdrom = 1;
-				config->fsg.luns[i].removable = 1;
-				config->fsg.luns[i].ro = 1;
+				config->fsg.luns[i].cdrom = 0;
+				config->fsg.luns[i].removable = 0;
+				config->fsg.luns[i].ro = 0;
 			} else {
 				config->fsg.luns[i].cdrom = 0;
 				config->fsg.luns[i].removable = 1;

--- a/drivers/usb/gadget/f_mass_storage.c
+++ b/drivers/usb/gadget/f_mass_storage.c
@@ -4174,10 +4174,6 @@ static struct fsg_common *fsg_common_init(struct fsg_common *common,
 			rc = fsg_lun_open(curlun, lcfg->filename);
 			if (rc)
 				goto error_luns;
-		} else if (!curlun->removable) {
-			ERROR(common, "no file given for LUN%d\n", i);
-			rc = -EINVAL;
-			goto error_luns;
 		}
 	}
 	common->nluns = nluns;

--- a/drivers/usb/gadget/storage_common.c
+++ b/drivers/usb/gadget/storage_common.c
@@ -790,8 +790,8 @@ static int fsg_lun_open(struct fsg_lun *curlun, const char *filename)
 	min_sectors = 1;
 	if (curlun->cdrom) {
 		min_sectors = 300;	/* Smallest track is 300 frames */
-		if (num_sectors >= 256*60*75) {
-			num_sectors = 256*60*75 - 1;
+		if (num_sectors >= 0xFFFFDF) {
+			num_sectors = 0xFFFFDF - 1;
 			LINFO(curlun, "file too big: %s\n", filename);
 			LINFO(curlun, "using only first %d blocks\n",
 					(int) num_sectors);


### PR DESCRIPTION
The first fixes CD-ROM mode to work with ISO files bigger than 2.2GB but not bigger than ~8GB. Not sure if bigger than 8GB would even work.

The second changes the phone to show up as a USB connected hard drive. Mainly a compatibility fix for Window-To-Go which does not allow booting with a removable device.
